### PR TITLE
Add simple API for adding and removing properties

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -121,14 +121,8 @@ Adding molecular properties
 
 .. testsetup:: adding_properties
 
-  import tempfile
-  import os
-  old_dir = os.getcwd()
-  temp_dir = tempfile.TemporaryDirectory()
-  os.chdir(temp_dir.name)
-
   import atomlite
-  db = atomlite.Database("molecules.db")
+  db = atomlite.Database(":memory:")
   import rdkit.Chem as rdkit
 
 We can add JSON properties to our molecular entries:
@@ -153,23 +147,13 @@ And retrieve them:
 
   {'is_interesting': False}
 
-.. testcleanup:: adding_properties
-
-  os.chdir(old_dir)
-
 Updating molecular properties
 .............................
 
 .. testsetup:: updating_properties
 
-  import tempfile
-  import os
-  old_dir = os.getcwd()
-  temp_dir = tempfile.TemporaryDirectory()
-  os.chdir(temp_dir.name)
-
   import atomlite
-  db = atomlite.Database("molecules.db")
+  db = atomlite.Database(":memory:")
   import rdkit.Chem as rdkit
 
 If we want to update molecular properties, we can use
@@ -220,10 +204,6 @@ Or remove properties:
 
    Entry(key='first', molecule={'atomic_numbers': [6]}, properties={'new': 20})
 
-.. testcleanup:: updating_properties
-
-  os.chdir(old_dir)
-
 .. note::
 
    The parameter ``merge_properties=False`` causes the entire property dictionary to
@@ -239,15 +219,9 @@ Updating entries
 
 .. testsetup:: updating_entries
 
-  import tempfile
-  import os
-  old_dir = os.getcwd()
-  temp_dir = tempfile.TemporaryDirectory()
-  os.chdir(temp_dir.name)
-
   import atomlite
-  db = atomlite.Database("molecules.db")
   import rdkit.Chem as rdkit
+  db = atomlite.Database(":memory:")
 
 We can update whole molecular entries in the database.
 Let's write our initial entry:
@@ -311,10 +285,6 @@ Or remove properties:
 
   Entry(key='first', molecule={'atomic_numbers': [35]}, properties={'new': 20})
 
-.. testcleanup:: updating_entries
-
-  os.chdir(old_dir)
-
 .. note::
 
    The parameter ``merge_properties=False`` causes the entire property dictionary to
@@ -323,6 +293,87 @@ Or remove properties:
 .. seealso::
 
   * :meth:`.Database.update_entries`: For additional documentaiton.
+
+Checking if a value exists in the database
+..........................................
+
+Sometimes you want to use a database as a cache to avoid recomputations.
+There is a simple way to do this!
+
+.. testsetup:: check_value_present
+
+  import atomlite
+  import rdkit.Chem as rdkit
+  db = atomlite.Database(":memory:")
+  db.add_entries(
+      entries=atomlite.Entry.from_rdkit(
+          key="first",
+          molecule=rdkit.MolFromSmiles("C"),
+      ),
+  )
+
+.. testcode:: check_value_present
+
+  molecule = rdkit.MolFromSmiles("CCC")
+  num_atoms = db.get_property("first", "$.physical.num_atoms")
+  if num_atoms is None:
+      num_atoms = molecule.GetNumAtoms()
+      db.set_property("first", "$.physical.num_atoms", num_atoms)
+  print(num_atoms)
+
+.. testoutput:: check_value_present
+
+  3
+
+.. _examples-valid-property-paths:
+
+Valid property paths
+....................
+
+Given a property dictionary:
+
+.. testcode:: valid_property_paths
+
+  properties = {
+      "a": {
+          "b": [1, 2, 3],
+          "c": 12,
+      },
+  }
+
+.. testcode:: valid_property_paths
+  :hide:
+
+  import atomlite
+  import rdkit.Chem as rdkit
+  db = atomlite.Database(":memory:")
+  db.add_entries(
+      entries=atomlite.Entry.from_rdkit(
+          key="first",
+          molecule=rdkit.MolFromSmiles("C"),
+          properties=properties,
+      ),
+  )
+
+we can access the various properties with the following paths:
+
+.. doctest:: valid_property_paths
+
+  >>> db.get_property("first", "$.a")
+  {'b': [1, 2, 3], 'c': 12}
+  >>> db.get_property("first", "$.a.b")
+  [1, 2, 3]
+  >>> db.get_property("first", "$.a.b[1]")
+  2
+  >>> db.get_property("first", "$.a.c")
+  12
+  >>> print(db.get_property("first", "$.a.does_not_exist"))
+  None
+
+A full description of the syntax is provided here_.
+
+.. _here: https://www.sqlite.org/json1.html#path_arguments
+
 
 Using an in-memory database
 ...........................

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -367,8 +367,8 @@ we can access the various properties with the following paths:
   2
   >>> db.get_property("first", "$.a.c")
   12
-  >>> print(db.get_property("first", "$.a.does_not_exist"))
-  None
+  >>> db.get_property("first", "$.a.does_not_exist") is None
+  True
 
 A full description of the syntax is provided here_.
 

--- a/src/atomlite/__init__.py
+++ b/src/atomlite/__init__.py
@@ -1,4 +1,9 @@
-from atomlite._internal.database import Database, Entry, PropertyEntry
+from atomlite._internal.database import (
+    Database,
+    Entry,
+    MoleculeNotFound,
+    PropertyEntry,
+)
 from atomlite._internal.json import (
     AromaticBonds,
     Bonds,
@@ -17,6 +22,7 @@ __all__ = [
     "AromaticBonds",
     "Database",
     "Entry",
+    "MoleculeNotFound",
     "PropertyEntry",
     "Json",
     "Molecule",

--- a/src/atomlite/_internal/json.py
+++ b/src/atomlite/_internal/json.py
@@ -2,7 +2,9 @@ import typing
 
 import rdkit.Chem as rdkit
 
-Json: typing.TypeAlias = float | str | None | list["Json"] | dict[str, "Json"]
+Json: typing.TypeAlias = (
+    bool | float | str | None | list["Json"] | dict[str, "Json"]
+)
 Conformer: typing.TypeAlias = list[list[float]]
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -19,6 +19,21 @@ class MultipleEntryCase:
     molecules: tuple[rdkit.Mol, ...]
 
 
+def test_set_property(database: atomlite.Database) -> None:
+    entry = atomlite.Entry.from_rdkit(
+        key="first",
+        molecule=rdkit.MolFromSmiles("C"),
+        properties={
+            "a": {
+                "b": 12,
+            },
+        },
+    )
+    database.add_entries(entry)
+    database.set_property("first", "$.a.c", 12)
+    assert database.get_property("first", "$.a.c") == 12
+
+
 def test_get_missing_property(database: atomlite.Database) -> None:
     entry = atomlite.Entry.from_rdkit(
         key="first",

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -19,6 +19,57 @@ class MultipleEntryCase:
     molecules: tuple[rdkit.Mol, ...]
 
 
+def test_get_missing_property(database: atomlite.Database) -> None:
+    entry = atomlite.Entry.from_rdkit(
+        key="first",
+        molecule=rdkit.MolFromSmiles("C"),
+        properties={
+            "a": {
+                "b": 12,
+            },
+        },
+    )
+    database.add_entries(entry)
+    assert database.get_property("first", "$.a.not_here") is None
+
+
+def test_get_property_from_missing_molecule(
+    database: atomlite.Database,
+) -> None:
+    with pytest.raises(atomlite.MoleculeNotFound):
+        database.get_property("first", "$.a.a")
+
+
+def test_get_property(database: atomlite.Database) -> None:
+    entry = atomlite.Entry.from_rdkit(
+        key="first",
+        molecule=rdkit.MolFromSmiles("C"),
+        properties={
+            "a": {
+                "b": 12,
+                "c": [1, 2, 3],
+                "d": "[4, 5, 6]",
+                "e": "hi",
+                "f": None,
+                "g": {"a": 12, "b": 24},
+                "h": True,
+                "i": False,
+                "j": 12.2,
+            },
+        },
+    )
+    database.add_entries(entry)
+    assert database.get_property("first", "$.a.b") == 12
+    assert database.get_property("first", "$.a.c") == [1, 2, 3]
+    assert database.get_property("first", "$.a.d") == "[4, 5, 6]"
+    assert database.get_property("first", "$.a.e") == "hi"
+    assert database.get_property("first", "$.a.f") is None
+    assert database.get_property("first", "$.a.g") == {"a": 12, "b": 24}
+    assert database.get_property("first", "$.a.h") is True
+    assert database.get_property("first", "$.a.i") is False
+    assert database.get_property("first", "$.a.j") == 12.2
+
+
 def test_entry_is_replaced_on_update(database: atomlite.Database) -> None:
     entry1 = atomlite.Entry.from_rdkit(
         key="first",


### PR DESCRIPTION
The `Database` class now has the methods `Database.add_property()`
and `Database.set_property()` which is should make it easier to use the 
database as a cache for calculation results.