### PR TITLE
Remove redundant int from Json type

### DIFF
--- a/src/atomlite/_internal/json.py
+++ b/src/atomlite/_internal/json.py
@@ -3,7 +3,7 @@ import typing
 import rdkit.Chem as rdkit
 
 Json: typing.TypeAlias = (
-    bool | int | float | str | None | list["Json"] | dict[str, "Json"]
+    bool | float | str | None | list["Json"] | dict[str, "Json"]
 )
 Conformer: typing.TypeAlias = list[list[float]]
 


### PR DESCRIPTION
I added the int initially because I thought it
would fix a type error. It didn't fix the error
so the int was in fact unnecessary.