### PR TITLE
Implement atomlite dump script for mol files.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,9 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atomlite"
-maintainers = [
-  { name = "Lukas Turcani", email = "lukasturcani93@gmail.com" },
-]
+maintainers = [{ name = "Lukas Turcani", email = "lukasturcani93@gmail.com" }]
 
-dependencies = [
-  "polars",
-  "rdkit>=2024.9.6",
-]
+dependencies = ["polars", "rdkit>=2024.9.6"]
 requires-python = ">=3.11"
 dynamic = ["version"]
 readme = "README.rst"
@@ -19,21 +14,24 @@ description = "A SQLite chemical database."
 
 [project.optional-dependencies]
 dev = [
-  "ruff",
-  "mypy",
-  "numpy",
-  "pytest",
-  "pytest-cov",
-  "sphinx",
-  "sphinx-copybutton",
-  "build",
-  "twine",
-  "furo",
+    "ruff",
+    "mypy",
+    "numpy",
+    "pytest",
+    "pytest-cov",
+    "sphinx",
+    "sphinx-copybutton",
+    "build",
+    "twine",
+    "furo",
 ]
 
 [project.urls]
 github = "https://github.com/lukasturcani/atomlite"
 documentation = "https://atomlite.readthedocs.io"
+
+[project.scripts]
+atomlite = "atomlite._internal.scripts.atomlite:main"
 
 [tool.setuptools_scm]
 
@@ -49,16 +47,16 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
-  "D100",
-  "D101",
-  "D102",
-  "D103",
-  "D104",
-  "D105",
-  "D106",
-  "D107",
-  "S101",
-  "INP001",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "S101",
+    "INP001",
 ]
 "docs/source/conf.py" = ["D100", "INP001"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,14 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "atomlite"
-maintainers = [{ name = "Lukas Turcani", email = "lukasturcani93@gmail.com" }]
+maintainers = [
+  { name = "Lukas Turcani", email = "lukasturcani93@gmail.com" },
+]
 
-dependencies = ["polars", "rdkit>=2024.9.6"]
+dependencies = [
+  "polars",
+  "rdkit>=2024.9.6",
+]
 requires-python = ">=3.11"
 dynamic = ["version"]
 readme = "README.rst"
@@ -14,16 +19,16 @@ description = "A SQLite chemical database."
 
 [project.optional-dependencies]
 dev = [
-    "ruff",
-    "mypy",
-    "numpy",
-    "pytest",
-    "pytest-cov",
-    "sphinx",
-    "sphinx-copybutton",
-    "build",
-    "twine",
-    "furo",
+  "ruff",
+  "mypy",
+  "numpy",
+  "pytest",
+  "pytest-cov",
+  "sphinx",
+  "sphinx-copybutton",
+  "build",
+  "twine",
+  "furo",
 ]
 
 [project.urls]
@@ -47,16 +52,16 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = [
-    "D100",
-    "D101",
-    "D102",
-    "D103",
-    "D104",
-    "D105",
-    "D106",
-    "D107",
-    "S101",
-    "INP001",
+  "D100",
+  "D101",
+  "D102",
+  "D103",
+  "D104",
+  "D105",
+  "D106",
+  "D107",
+  "S101",
+  "INP001",
 ]
 "docs/source/conf.py" = ["D100", "INP001"]
 

--- a/src/atomlite/_internal/scripts/atomlite.py
+++ b/src/atomlite/_internal/scripts/atomlite.py
@@ -44,8 +44,13 @@ def main() -> None:
             raise RuntimeError(msg)
 
         db = Database(args.database_path)
+        entry = db.get_entry(args.entry_key)
+        if entry is None:
+            msg = f"entry {args.entry_key} not found"
+            raise RuntimeError(msg)
+
         rdkit.MolToMolFile(
-            mol=json_to_rdkit(db.get_entry(args.entry_key).molecule),
+            mol=json_to_rdkit(entry.molecule),
             filename=args.dump_path,
             forceV3000=True,
         )

--- a/src/atomlite/_internal/scripts/atomlite.py
+++ b/src/atomlite/_internal/scripts/atomlite.py
@@ -11,6 +11,7 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s | %(levelname)s | %(message)s",
 )
+logger = logging.getLogger(__name__)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -29,7 +30,7 @@ def _parse_args() -> argparse.Namespace:
     dump.add_argument(
         "dump_path",
         type=pathlib.Path,
-        help="path to mol file",
+        help="path to file",
     )
 
     return parser.parse_args()
@@ -38,12 +39,17 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
     if args.command == "dump":
+        if args.dump_path.suffix not in (".mol",):
+            msg = "only .mol files are supported"
+            raise RuntimeError(msg)
+
         db = Database(args.database_path)
         rdkit.MolToMolFile(
             mol=json_to_rdkit(db.get_entry(args.entry_key).molecule),
             filename=args.dump_path,
             forceV3000=True,
         )
+        logger.info("dumped %s to %s", args.entry_key, args.dump_path)
 
 
 if __name__ == "__main__":

--- a/src/atomlite/_internal/scripts/atomlite.py
+++ b/src/atomlite/_internal/scripts/atomlite.py
@@ -1,0 +1,50 @@
+import argparse
+import logging
+import pathlib
+
+import rdkit.Chem as rdkit  # noqa: N813
+
+from atomlite._internal.database import Database
+from atomlite._internal.json import json_to_rdkit
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)s | %(message)s",
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    dump = subparsers.add_parser(
+        "dump",
+        help="write a molecule from a database to a file (only .mol for now)",
+    )
+    dump.add_argument(
+        "database_path",
+        type=pathlib.Path,
+        help="path to atomlite database",
+    )
+    dump.add_argument("entry_key", help="entry key of molecule")
+    dump.add_argument(
+        "dump_path",
+        type=pathlib.Path,
+        help="path to mol file",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.command == "dump":
+        db = Database(args.database_path)
+        rdkit.MolToMolFile(
+            mol=json_to_rdkit(db.get_entry(args.entry_key).molecule),
+            filename=args.dump_path,
+            forceV3000=True,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request implements a script into the atomlite module that allows the user to write a .mol file (using rdkit) from a database given an entry key.

the command looks like:
`uv run atomlite dump molecules.db second second.mol`

And this sets up the infrastructure for future atomlite scripts.